### PR TITLE
Fix trimStartSpaces

### DIFF
--- a/lua/themery/utils.lua
+++ b/lua/themery/utils.lua
@@ -6,8 +6,14 @@ local function centerHorizontal(str)
   return string.rep(' ', shift) .. str
 end
 
-local function trimStartSpaces(s)
-  return string.gsub(s, "[^%S\n]+", "")
+local function trimStartSpaces(text)
+    lines = {}
+    for s in text:gmatch("([^\n]*)\n?") do
+        line, _ = string.gsub(s, "^%s*(.-)%s*$", "%1")
+        table.insert(lines, line)
+    end
+
+    return table.concat(lines, "\n")
 end
 
 local function dump(o)


### PR DESCRIPTION
I used the following snippet to test the new function.

```lua
text = [[
  local hello = "world"
  local n = 23

a = 3
  function()
    a = 4
  end
]]

lines = {}
for s in text:gmatch("([^\n]*)\n?") do
    line, _ = string.gsub(s, "^%s*(.-)%s*$", "%1")
    table.insert(lines, line)
end

print(table.concat(lines, "\n"))
```

You'll notice how with the old function, all middle spaces are removed, which makes it imposible to define variables in the before/after theme config