### PR TITLE
feat: use a theme_id (position of the theme in the lua table) to dete…

### DIFF
--- a/lua/themery/controller.lua
+++ b/lua/themery/controller.lua
@@ -5,123 +5,133 @@ local window = require("themery.window")
 local api = vim.api
 
 local position = 0
-local currentThemeIndex = -1
-local currentThemeName = ""
 local resultsStart = constants.RESULTS_TOP_MARGIN
+local currentThemeId = vim.g.theme_id
 
 local function loadActualThemeConfig()
-  local themeList = config.getSettings().themes;
-  currentThemeName = vim.g.colors_name
+	local themeList = config.getSettings().themes
 
-  for k in pairs(themeList) do
-    if currentThemeName == themeList[k].colorscheme then
-      currentThemeIndex = k
-      position = k + resultsStart - 1
-      return
-    end
-  end
+	-- if currentThemeId isn't set, it's because it's the first time it has been run
+	if not currentThemeId then
+		position = resultsStart
+		return
+	end
+
+	for k in pairs(themeList) do
+		if currentThemeId == k then
+			position = k + resultsStart - 1
+			return
+		end
+	end
 end
 
 local function setColorscheme(theme)
-  if theme.before then
-    local fn, err = load(theme.before)
-    if err then
-      print("Themery error: "..err)
-      return false
-    end
-    if fn then fn() end
-  end
+	if theme.before then
+		local fn, err = load(theme.before)
+		if err then
+			print("Themery error: " .. err)
+			return false
+		end
+		if fn then
+			fn()
+		end
+	end
 
-  local ok, _ = pcall(
-    vim.cmd,
-    "colorscheme "..theme.colorscheme
-  )
+	local ok, _ = pcall(vim.cmd, "colorscheme " .. theme.colorscheme)
 
-  -- check if the colorscheme was loaded successfully
-  if not ok then
-    print(constants.MSG_ERROR.THEME_NOT_LOADED..": "..theme)
-    -- Restore previus
-    vim.cmd('colorscheme '..currentThemeName)
-    return false
-  end
+	-- check if the colorscheme was loaded successfully
+	if not ok then
+		print(constants.MSG_ERROR.THEME_NOT_LOADED .. ": " .. theme)
+		-- Restore previus
+		vim.cmd("colorscheme " .. config.getSettings().themes[currentThemeId])
+		return false
+	end
 
-  if theme.after then
-    local fn, err = load(theme.after)
-    if err then
-      print(constants.MSG_ERROR.GENERIC..": "..err)
-      return false
-    end
-    if fn then fn() end
-  end
+	if theme.after then
+		local fn, err = load(theme.after)
+		if err then
+			print(constants.MSG_ERROR.GENERIC .. ": " .. err)
+			return false
+		end
+		if fn then
+			fn()
+		end
+	end
 
-  return true
+	return true
 end
 
 local function updateView(direction)
-  local themeList = config.getSettings().themes;
-  position = position + direction
-  vim.api.nvim_buf_set_option(window.getBuf(), 'modifiable', true)
-  if position < resultsStart then position = resultsStart end
-  if position > #themeList + 1 then position = #themeList + 1 end
+	local themeList = config.getSettings().themes
+	position = position + direction
+	vim.api.nvim_buf_set_option(window.getBuf(), "modifiable", true)
+	if position < resultsStart then
+		position = resultsStart
+	end
+	if position > #themeList + 1 then
+		position = #themeList + 1
+	end
 
-  if #themeList == 0 then
-    window.printNoThemesLoaded()
-    vim.api.nvim_buf_set_option(window.getBuf(), 'modifiable', false)
-    return
-  end
+	if #themeList == 0 then
+		window.printNoThemesLoaded()
+		vim.api.nvim_buf_set_option(window.getBuf(), "modifiable", false)
+		return
+	end
 
-  local resultToPrint = {}
-  for i in ipairs(themeList) do
-    local prefix = '  '
+	local resultToPrint = {}
+	for i in ipairs(themeList) do
+		local prefix = "  "
 
-    if currentThemeIndex == i then
-      prefix = '> '
-    end
+		if currentThemeId == i then
+			prefix = "> "
+		end
 
-    resultToPrint[i] = prefix..themeList[i].name
-  end
+		resultToPrint[i] = prefix .. themeList[i].name
+	end
 
-  api.nvim_buf_set_lines(window.getBuf(), 1, -1, false, resultToPrint)
-  api.nvim_win_set_cursor(window.getWin(), {position, 0})
+	api.nvim_buf_set_lines(window.getBuf(), 1, -1, false, resultToPrint)
+	api.nvim_win_set_cursor(window.getWin(), { position, 0 })
 
-  if config.getSettings().livePreview then
-    setColorscheme(themeList[position-1])
-  end
+	if config.getSettings().livePreview then
+		setColorscheme(themeList[position - 1])
+	end
 
-  vim.api.nvim_buf_set_option(window.getBuf(), 'modifiable', false)
+	vim.api.nvim_buf_set_option(window.getBuf(), "modifiable", false)
 end
 
 local function revertTheme()
-  setColorscheme(config.getSettings().themes[currentThemeIndex])
+	-- setColorscheme(config.getSettings().themes[currentThemeIndex])
+	setColorscheme(config.getSettings().themes[currentThemeId])
 end
 
 local function open()
-  window.openWindow()
-  loadActualThemeConfig()
-  updateView(0)
+	window.openWindow()
+	loadActualThemeConfig()
+	updateView(0)
 end
 
 local function close()
-  window.closeWindow()
+	window.closeWindow()
 end
 
 local function closeAndRevert()
-  revertTheme()
-  window.closeWindow()
+	revertTheme()
+	window.closeWindow()
 end
 
 local function closeAndSave()
-  local theme = config.getSettings().themes[position-1]
-  persistence.saveTheme(theme)
-  window.closeWindow()
+	local theme = config.getSettings().themes[position - 1]
+	persistence.saveTheme(theme, position - 1)
+	currentThemeId = position - 1
+	window.closeWindow()
 end
 
 return {
-  open = open,
-  close = close,
-  closeAndRevert = closeAndRevert,
-  closeAndSave = closeAndSave,
-  updateView = updateView,
-  loadActualThemeConfig = loadActualThemeConfig,
-  setColorscheme = setColorscheme,
+	open = open,
+	close = close,
+	closeAndRevert = closeAndRevert,
+	closeAndSave = closeAndSave,
+	updateView = updateView,
+	loadActualThemeConfig = loadActualThemeConfig,
+	setColorscheme = setColorscheme,
 }

--- a/lua/themery/persistence.lua
+++ b/lua/themery/persistence.lua
@@ -2,62 +2,65 @@ local constants = require("themery.constants")
 local config = require("themery.config")
 local utils = require("themery.utils")
 
-local function saveTheme(theme)
-  local configFilePath = config.getSettings().themeConfigFile
-  local file = io.open(configFilePath , "r")
+local function saveTheme(theme, theme_id)
+	local configFilePath = config.getSettings().themeConfigFile
+	local file = io.open(configFilePath, "r")
 
-  if file == nil then
-    print(constants.MSG_ERROR.READ_FILE..": "..configFilePath)
-    return
-  end
+	if file == nil then
+		print(constants.MSG_ERROR.READ_FILE .. ": " .. configFilePath)
+		return
+	end
 
-  local content = file:read("*all")
+	local content = file:read("*all")
 
-  local start_marker = "-- Themery block"
-  local end_marker = "-- end themery block"
+	local start_marker = "-- Themery block"
+	local end_marker = "-- end themery block"
 
-  local start_pos, end_pos = content:find(start_marker .. "\n(.+)\n" .. end_marker)
+	local start_pos, end_pos = content:find(start_marker .. "\n(.+)\n" .. end_marker)
 
-  if not start_pos or not end_pos then
-    print(constants.MSG_ERROR.NO_MARKETS)
-    return
-  end
+	if not start_pos or not end_pos then
+		print(constants.MSG_ERROR.NO_MARKETS)
+		return
+	end
 
-  local beforeCode = ""
-  local afterCode = ""
+	local beforeCode = ""
+	local afterCode = ""
 
-  if theme.before then
-    beforeCode = utils.trimStartSpaces(theme.before).."\n"
-  end
+	if theme.before then
+		beforeCode = utils.trimStartSpaces(theme.before) .. "\n"
+	end
 
-  if theme.after then
-    afterCode = "\n"..utils.trimStartSpaces(theme.after)
-  end
+	if theme.after then
+		afterCode = "\n" .. utils.trimStartSpaces(theme.after)
+	end
 
-  local configToWrite = "-- This block will be replaced by Themery.\n"
-  configToWrite = configToWrite..beforeCode
-  configToWrite = configToWrite.."vim.cmd(\"colorscheme "
-  configToWrite = configToWrite..theme.colorscheme.."\")\n"
-  configToWrite = configToWrite..afterCode
+	local configToWrite = "-- This block will be replaced by Themery.\n"
+	configToWrite = configToWrite .. beforeCode
+	configToWrite = configToWrite .. 'vim.cmd("colorscheme '
+	configToWrite = configToWrite .. theme.colorscheme .. '")\n'
+	configToWrite = configToWrite .. afterCode
+	configToWrite = configToWrite .. "vim.g.theme_id = " .. theme_id
 
-local replaced_content = content:sub(1, start_pos-1)
-    ..start_marker.."\n"
-    ..configToWrite
-    ..end_marker
-    ..content:sub(end_pos+1)
+	local replaced_content = content:sub(1, start_pos - 1)
+		.. start_marker
+		.. "\n"
+		.. configToWrite
+		.. "\n"
+		.. end_marker
+		.. content:sub(end_pos + 1)
 
-  local outfile = io.open(configFilePath, "w")
+	local outfile = io.open(configFilePath, "w")
 
-  if outfile == nil then
-    print(constants.MSG_ERROR.WRITE_FILE..": "..configFilePath)
-    return
-  end
+	if outfile == nil then
+		print(constants.MSG_ERROR.WRITE_FILE .. ": " .. configFilePath)
+		return
+	end
 
-  outfile:write(replaced_content)
-  outfile:close()
-  print(constants.MSG_INFO.THEME_SAVED)
+	outfile:write(replaced_content)
+	outfile:close()
+	print(constants.MSG_INFO.THEME_SAVED)
 end
 
 return {
-  saveTheme = saveTheme,
+	saveTheme = saveTheme,
 }


### PR DESCRIPTION
# Problem
When providing multiple variations/flavors of a theme to `themery` config, a couple of issues may arise:

1. When the theme selector buffer is opened, the cursor is set to the wrong line/theme
2. When the theme selector buffer is opened, the `>` character is placed in front of the wrong theme

For example, I provided two different variations of [`gruvbox-flat`](https://github.com/eddyekofo94/gruvbox-flat.nvim) to themery config. To use a darker variation of the base theme, the theme requires a global variable to be set: `vim.g.gruvbox_flat_style = "dark"`. So I have one `gruvbox-flat` theme that uses the base defaults and one that's darker.

The issue is that `themery` isn't aware of the difference between the two because it uses `vim.g.colors_name` to determine what the currently set theme is. In my example, `vim.g.colors_name` would return the same value (`gruvbox-flat`) regardless of what variation of the theme I have set.

# Solution
Introduce `currentThemeId` variable in `controller.lua` to better keep track of what the currently set theme is. `currentThemeId` just uses the theme's position in the config table. This replaces the need for `currentThemeName` and `currentThemeIndex`. This ensures that the cursor is placed on the current theme when `themery` is opened and it ensures that `>` is placed in front of the current theme.

For persistence, it writes `vim.g.theme_id = <theme_id>` to the provided config file.

The one small drawback is that when `themery` is initially opened (before `vim.g.theme_id` is set), it doesn't know what the current theme is yet. In this case, the cursor will just be set to the first result in the theme picker (`resultsStart`) and the `>` character will not yet be printed in front of any of the themes. However, I think this is a good compromise.