### PR TITLE
Fix persistence of theme change during in-session calls to themery

### DIFF
--- a/lua/themery/controller.lua
+++ b/lua/themery/controller.lua
@@ -128,6 +128,9 @@ local function closeAndSave()
 	local theme = config.getSettings().themes[position - 1]
 	persistence.saveTheme(theme, position - 1)
 	selectedThemeId = position - 1
+  -- sarmun's fix begin
+  vim.g.theme_id = selectedThemeId
+  -- sarmun's fix end
 	window.closeWindow()
 end
 


### PR DESCRIPTION
Themery didn't update the g:theme_id in running nvim, only in the file. This resulted in going back to the theme set in persistence file every time Themery was called. This fix soles the issue.