### PR TITLE
Create get_installed_themes.lua

### DIFF
--- a/lua/themery/get_installed_themes.lua
+++ b/lua/themery/get_installed_themes.lua
@@ -1,0 +1,11 @@
+local Installed_Themes = {}
+
+local all_installed_themes = vim.fn.getcompletion("", "color")
+
+local default_vim_themes = { "blue", "darkblue", "default", "delek", "desert", "elflord", "evening", "habamax", "industry", "koehler", "lunaperche", "morning", "murphy", "pablo", "peachpuff", "quiet", "ron", "shine", "slate", "torte", "zellner", }
+
+Installed_Themes.all_installed_themes = all_installed_themes
+
+Installed_Themes.default_vim_themes = default_vim_themes
+
+return Installed_Themes


### PR DESCRIPTION
Hi
(I am new to git, so please bare with me)

I made a new file as I didn't know where to put this but I am happy to change it.

Basically I am returning a lua table that has 2 properties.
1) all_installed_themes: this gets all of the currently installed themes from vim itself so you don't have to manually enter the name of all the themes.
2) default_vim_themes: this is a list of all of the default themes installed in neovim when you first download nvim

I think it is good to have this as you can choose to filter out the default installed themes later.

I made a simple theme picker using telescope that I would be happy to share with you if you want to see it