### PR TITLE
Add API for theme management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Themery is a plugin for Neovim written in Lua which allows you to quickly switch
 
 - [Features](#features)
 - [Motivation](#motivation)
+- [Usage](#usage)
 - [Installation](#installation)
   - [vim-plug](#vim-plug)
   - [Packer](#packer)
@@ -18,7 +19,8 @@ Themery is a plugin for Neovim written in Lua which allows you to quickly switch
     - [Minimal config](#minimal-config)
     - [Customizing names](#customizing-names)
     - [Executing code on theme apply](#executing-code-on-theme-apply)
-- [Usage](#usage)
+- [API](#API)
+  - [Example - Alternate between 2 themes](#Example---Alternate-between-2-themes)
 - [License](#license)
 
 ## Features
@@ -137,17 +139,39 @@ That is, everything inside those variables will be executed as Lua code.
 > [!IMPORTANT]  
 > Note that all code in after and before must be declared as a string. That is, wrapped between '[[' and ']]' and not as a function.
 
+## API
+
+Themery exposes several functions that you can use to interact with themes programmatically.
+
+- `getCurrentTheme()`: Return the current theme configured (a table with **index** (int) and **name** (string)), or nil.
+- `setThemeByName(name:string, shouldSave:boolean)`: Set a theme based on the name specified. If shouldSave is true, the selection will be saved. _The name refers to the name chosen by the user in the configuration and not to the name of the colorscheme_.
+- `setThemeByIndex(index:Int, shouldSave:boolean)`: Sets the colour scheme that occupies the index specified in the list of themes in the themery configuration, starting from 1. If shouldSave is true, the selection will be saved.
+
+> [!NOTE]
+> More will be added gradually, but if you have something in mind and need more control, feel free to open an issue!
+
+### Example - Alternate between 2 themes
+
+The following example illustrates how to use the above methods to switch between light and dark mode:
+
+```lua
+vim.keymap.set("n", "<leader>tt", function()
+	local themery = require("themery")
+	local currentTheme = themery.getCurrentTheme()
+	if currentTheme and currentTheme.name == "gruvbox light" then
+		themery.setThemeByName("gruvbox dark", true)
+	else
+		themery.setThemeByName("gruvbox light", true)
+	end
+end, { noremap = true })
+```
+
 ## WIP
 
 **Project under development.**
 Many things can change at any time and the plugin may not be stable.
 
 **Let me know if you have any suggestions, comments or bugs!**
-
-### To-do
-
-- Add categories (Light/Dark).
-- Expose the API to be able to switch between themes without opening the menu.
 
 In the future I would like the plugin to become a complete theme manager so that themes can be tested on the fly before installing them or browsing through a community repertoire.
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ That is, everything inside those variables will be executed as Lua code.
 Themery exposes several functions that you can use to interact with themes programmatically.
 
 - `getCurrentTheme()`: Return the current theme configured (a table with **index** (int) and **name** (string)), or nil.
-- `setThemeByName(name:string, shouldSave:boolean)`: Set a theme based on the name specified. If shouldSave is true, the selection will be saved. _The name refers to the name chosen by the user in the configuration and not to the name of the colorscheme_.
-- `setThemeByIndex(index:Int, shouldSave:boolean)`: Sets the colour scheme that occupies the index specified in the list of themes in the themery configuration, starting from 1. If shouldSave is true, the selection will be saved.
+- `getAvailableThemes()`: Return a table with all available themes configured in themery.
+- `setThemeByName(name:string, makePersistent:boolean)`: Set a theme based on the name specified. If makePersistent is set to true, the changes will persist even after closing neovim, loading that theme on startup. _The name refers to the name chosen by the user in the configuration and not to the name of the colorscheme_.
+- `setThemeByIndex(index:Int, makePersistent:boolean)`: Sets the colour scheme that occupies the index specified in the list of themes in the themery configuration, starting from 1. If makePersistent is set to true, the changes will persist even after closing neovim, loading that theme on startup.
 
 > [!NOTE]
 > More will be added gradually, but if you have something in mind and need more control, feel free to open an issue!

--- a/lua/themery/controller.lua
+++ b/lua/themery/controller.lua
@@ -152,20 +152,20 @@ end
 -- searches for the theme with the specified name, and applies the colorscheme.
 --
 -- @param name string The name of the theme to apply.
--- @param shouldSave boolean Whether to save the current state after applying the colorscheme.
+-- @param makePersistent boolean Whether to save the current state after applying the colorscheme.
 -- @usage
 -- 	 setThemeByName("monokai") -- Applies the monokai theme
 --
 -- @error Prints an error message if the theme is not found.
-local function setThemeByName(name, shouldSave)
-	shouldSave = shouldSave or false
+local function setThemeByName(name, makePersistent)
+	makePersistent = makePersistent or false
 	local themes = config.getSettings().themes
 	for index, theme in ipairs(themes) do
 		if theme.name == name or theme.colorscheme == name then
 			position = index + 1
 			selectedThemeId = index + 1
 			setColorscheme(themes[index])
-			if shouldSave then
+			if makePersistent then
 				save()
 			end
 			return
@@ -181,13 +181,13 @@ end
 -- colorscheme, the current state is saved.
 --
 -- @param index number The index of the theme to apply. Must be between 1 and the total number of available themes.
--- @param shouldSave boolean Whether to save the current state after applying the colorscheme.
+-- @param makePersistent boolean Whether to save the current state after applying the colorscheme.
 -- @usage
 --   setThemeByIndex(2)  -- Applies the theme at index 2
 --
 -- @error Prints an error message if the index is invalid.
-local function setThemeByIndex(index, shouldSave)
-	shouldSave = shouldSave or false
+local function setThemeByIndex(index, makePersistent)
+	makePersistent = makePersistent or false
 	local themes = config.getSettings().themes
 	if index < 1 or index > #themes then
 		print("Themery: Invalid index. Should be between 1 and " .. #themes .. ".")
@@ -196,7 +196,7 @@ local function setThemeByIndex(index, shouldSave)
 	position = index + 1
 	selectedThemeId = index
 	setColorscheme(themes[index])
-	if shouldSave then
+	if makePersistent then
 		save()
 	end
 end
@@ -217,6 +217,14 @@ local function getCurrentTheme()
 	end
 end
 
+--- Retrieves the available themes.
+--
+-- @return table A table containing the available themes.
+local function getAvailableThemes()
+	loadActualThemeConfig()
+	return config.getSettings().themes
+end
+
 local function bootstrap()
 	loadActualThemeConfig()
 	persistence.loadState() 
@@ -235,4 +243,5 @@ return {
 	setThemeByName = setThemeByName,
 	setThemeByIndex = setThemeByIndex,
 	getCurrentTheme = getCurrentTheme,
+	getAvailableThemes = getAvailableThemes
 }

--- a/lua/themery/controller.lua
+++ b/lua/themery/controller.lua
@@ -135,12 +135,86 @@ local function closeAndRevert()
 	window.closeWindow()
 end
 
-local function closeAndSave()
+local function save()
 	local theme = config.getSettings().themes[position - 1]
 	persistence.saveTheme(theme, position - 1)
 	selectedThemeId = position - 1
 	vim.g.theme_id = selectedThemeId
+end
+
+local function closeAndSave()
+	save()
 	window.closeWindow()
+end
+
+--- Sets the colorscheme based on the specified name.
+-- This function retrieves the list of available themes from the config,
+-- searches for the theme with the specified name, and applies the colorscheme.
+--
+-- @param name string The name of the theme to apply.
+-- @param shouldSave boolean Whether to save the current state after applying the colorscheme.
+-- @usage
+-- 	 setThemeByName("monokai") -- Applies the monokai theme
+--
+-- @error Prints an error message if the theme is not found.
+local function setThemeByName(name, shouldSave)
+	shouldSave = shouldSave or false
+	local themes = config.getSettings().themes
+	for index, theme in ipairs(themes) do
+		if theme.name == name or theme.colorscheme == name then
+			position = index + 1
+			selectedThemeId = index + 1
+			setColorscheme(themes[index])
+			if shouldSave then
+				save()
+			end
+			return
+		end
+	end
+	print("Themery: Theme \"" .. name .. "\" not found.")
+end
+
+--- Sets the colorscheme based on the specified index.
+-- This function retrieves the list of available themes from the config,
+-- validates the provided index, and applies the colorscheme at that index.
+-- If the index is out of range, an error message is printed. After setting the
+-- colorscheme, the current state is saved.
+--
+-- @param index number The index of the theme to apply. Must be between 1 and the total number of available themes.
+-- @param shouldSave boolean Whether to save the current state after applying the colorscheme.
+-- @usage
+--   setThemeByIndex(2)  -- Applies the theme at index 2
+--
+-- @error Prints an error message if the index is invalid.
+local function setThemeByIndex(index, shouldSave)
+	shouldSave = shouldSave or false
+	local themes = config.getSettings().themes
+	if index < 1 or index > #themes then
+		print("Themery: Invalid index. Should be between 1 and " .. #themes .. ".")
+		return
+	end
+	position = index + 1
+	selectedThemeId = index
+	setColorscheme(themes[index])
+	if shouldSave then
+		save()
+	end
+end
+
+--- Retrieves the current theme..
+--
+-- @return table|nil A table containing the name and index of the current theme if it exists, or nil if not.
+local function getCurrentTheme()
+	loadActualThemeConfig()
+	local themes = config.getSettings().themes
+	if themes[selectedThemeId] then
+		return {
+			name = themes[selectedThemeId].name,
+			index = position
+		}
+	else
+		return nil
+	end
 end
 
 local function bootstrap()
@@ -158,4 +232,7 @@ return {
 	loadActualThemeConfig = loadActualThemeConfig,
 	setColorscheme = setColorscheme,
 	bootstrap = bootstrap,
+	setThemeByName = setThemeByName,
+	setThemeByIndex = setThemeByIndex,
+	getCurrentTheme = getCurrentTheme,
 }

--- a/lua/themery/init.lua
+++ b/lua/themery/init.lua
@@ -61,4 +61,7 @@ return {
 	closeAndRevert = controller.closeAndRevert,
 	closeAndSave = controller.closeAndSave,
 	updateView = controller.updateView,
+	setThemeByName = controller.setThemeByName,
+	setThemeByIndex = controller.setThemeByIndex,
+	getCurrentTheme = controller.getCurrentTheme,
 }

--- a/lua/themery/init.lua
+++ b/lua/themery/init.lua
@@ -64,4 +64,5 @@ return {
 	setThemeByName = controller.setThemeByName,
 	setThemeByIndex = controller.setThemeByIndex,
 	getCurrentTheme = controller.getCurrentTheme,
+	getAvailableThemes = controller.getAvailableThemes,
 }


### PR DESCRIPTION
It sets out the following methods for interacting with the plugin:

- `setThemeByName(name:string, shouldSave:boolean)`
- `setThemeByIndex(index:Int, shouldSave:boolean)`
- `getCurrentTheme()`

It also includes an example for switching between light and dark themes.

Closes #24 