### PR TITLE
docs: add lazy.nvim to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ Plug 'zaldih/themery.nvim'
 use 'zaldih/themery.nvim'
 ```
 
+### lazy.nvim
+
+```lua
+return {
+    "zaldih/themery.nvim",
+    lazy = false,
+    config = function()
+      require("themery").setup({
+        -- add the config here
+      })
+    end
+  }
+```
+
 ## Configuration
 
 Configuration is simple and intuitive.


### PR DESCRIPTION
## Description

Thanks for this great project!

This PR adds the missing installation guide for `lazy.nvim`, because only after some trial and error I figured that I have to add `lazy = false` to the config to get the saved theme immediately.

closes #32